### PR TITLE
Feature/https tekiou authcontroller fix

### DIFF
--- a/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/config/SecurityConfig.java
+++ b/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/config/SecurityConfig.java
@@ -39,7 +39,8 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable()) // CSRF保護を無効化
                 .authorizeHttpRequests(auth -> auth
                         // 特定のエンドポイントは認証なしでアクセス可能に設定
-                        .requestMatchers("/auth/signup", "/auth/login", "/css/**", "/js/**", "/images/**", "/comments",
+                        .requestMatchers("/", "/auth/signup", "/auth/login", "/css/**", "/js/**", "/images/**",
+                                "/comments",
                                 "/links", "/auth/userinfo", "/api/visitorCounter/**", "/api/proud/**", "/proud")
                         .permitAll()
                         // それ以外のリクエストは認証が必要

--- a/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/controller/AuthController.java
+++ b/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/controller/AuthController.java
@@ -21,6 +21,13 @@ public class AuthController {
     @Autowired
     private UserService userService;
 
+    // 新規追加: / (ルート) エンドポイント
+    @GetMapping("/")
+    public String rootRedirect() {
+        // ルートへのアクセスは常にログイン画面にリダイレクト
+        return "redirect:/auth/login";
+    }
+
     @GetMapping("/signup")
     public String signupPage() {
         return "signup"; // src/main/resources/templates/signup.html
@@ -32,8 +39,7 @@ public class AuthController {
             @RequestParam(value = "logout", required = false) String logout,
             Model model) {
         if ("true".equals(error)) {
-            model.addAttribute("errorMessage", "ユーザ名かパスワードが正しくありません");// "Invalid username or password. Please try
-                                                                      // again."
+            model.addAttribute("errorMessage", "ユーザ名かパスワードが正しくありません");
         }
         if ("true".equals(logout)) {
             model.addAttribute("message", "ログアウトしました");
@@ -48,20 +54,18 @@ public class AuthController {
         try {
             // ユーザー名の重複チェック
             if (userService.isUsernameTaken(username)) {
-                model.addAttribute("message", "ユーザー名はすでに使用されています。別のユーザー名を選択してください");// "Username is already taken.
-                                                                                    // Please choose a different one."
+                model.addAttribute("message", "ユーザー名はすでに使用されています。別のユーザー名を選択してください");
                 return "signup"; // 登録ページに戻る
             }
 
             // ユーザー登録処理
             userService.saveUser(username, password);
 
-            model.addAttribute("message", "ユーザー登録完了！");// User registered successfully
+            model.addAttribute("message", "ユーザー登録完了！");
             System.out.println("DEBUG: User successfully registered - username: " + username);
             return "signup-success";
         } catch (Exception e) {
-            model.addAttribute("message", "予期しないエラーが発生しました。もう一度お試しください");// "An unexpected error occurred. Please try
-                                                                         // again."
+            model.addAttribute("message", "予期しないエラーが発生しました。もう一度お試しください");
             e.printStackTrace();
             return "signup";
         }
@@ -69,10 +73,10 @@ public class AuthController {
 
     @GetMapping("/role")
     public ResponseEntity<Map<String, String>> getUserRole(Authentication authentication) {
-        System.out.println("DEBUG: /auth/role endpoint accessed"); // デバッグログ
+        System.out.println("DEBUG: /auth/role endpoint accessed");
 
         if (authentication == null || !authentication.isAuthenticated()) {
-            System.out.println("DEBUG: Unauthorized access to /auth/role"); // デバッグログ
+            System.out.println("DEBUG: Unauthorized access to /auth/role");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 
@@ -84,23 +88,23 @@ public class AuthController {
         Map<String, String> response = new HashMap<>();
         response.put("role", role);
 
-        System.out.println("DEBUG: User role fetched - role: " + role); // デバッグログ
+        System.out.println("DEBUG: User role fetched - role: " + role);
         return ResponseEntity.ok(response);
     }
 
     @PostMapping("/login")
     @ResponseBody
     public ResponseEntity<String> login(@RequestParam String username, @RequestParam String password) {
-        System.out.println("DEBUG: login endpoint called with username: " + username); // デバッグログ
+        System.out.println("DEBUG: login endpoint called with username: " + username);
 
         // ログイン処理を呼び出す
         boolean success = userService.authenticate(username, password);
 
         if (success) {
-            System.out.println("DEBUG: Login successful for username: " + username); // デバッグログ
+            System.out.println("DEBUG: Login successful for username: " + username);
             return ResponseEntity.ok("Login successful");
         } else {
-            System.out.println("DEBUG: Login failed for username: " + username); // デバッグログ
+            System.out.println("DEBUG: Login failed for username: " + username);
             return ResponseEntity.status(401).body("Invalid username or password");
         }
     }


### PR DESCRIPTION
HTTPS 通信の正常化(正常に HTTPS 通信が利用できていることを確認)

設定した SSL 証明書により、https://letsgoohtanifromjapan.click で安全な通信が確立されています。これにより、ブラウザの鍵マークも表示されて「安全ではありません」の警告が解消されています。
証明書の自動更新設定

0 2 * * 1 /usr/bin/certbot renew --quiet && sudo systemctl reload nginx
毎週月曜日の午前2時に証明書を自動更新し、Nginx を再起動する設定が crontab に登録されているので、更新作業は自動で実行されます