### PR TITLE
/images に手動で画像置いておけばあとはI/Fから追加できるところまで作成

### DIFF
--- a/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/config/SecurityConfig.java
+++ b/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/config/SecurityConfig.java
@@ -42,6 +42,7 @@ public class SecurityConfig {
                                 "/icon.png", "/sw.js", "/notifications/**", "/subscriptions/**",
                                 "/notifications/comments", "/api/news", "/home")
                         .permitAll()
+                        .requestMatchers("/admin/**").hasRole("ADMIN") // 管理者専用エンドポイントを保護
                         .anyRequest().authenticated())
                 .formLogin(form -> form
                         .loginPage("/auth/login")

--- a/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/controller/AdminNewsController.java
+++ b/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/controller/AdminNewsController.java
@@ -1,0 +1,32 @@
+package com.example.dodgersshoheiapp.controller;
+
+import com.example.dodgersshoheiapp.model.NewsUpdate;
+import com.example.dodgersshoheiapp.repository.NewsUpdateRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequestMapping("/admin/news")
+public class AdminNewsController {
+
+    @Autowired
+    private NewsUpdateRepository newsUpdateRepository;
+
+    // 管理者専用のニュース管理画面を表示
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public String showAdminNewsPage() {
+        return "admin-news"; // templates/admin-news.html を返す
+    }
+
+    // ニュースを追加するエンドポイント
+    @PostMapping("/add")
+    @ResponseBody
+    @PreAuthorize("hasRole('ADMIN')")
+    public String addNews(@RequestBody NewsUpdate newsUpdate) {
+        newsUpdateRepository.save(newsUpdate);
+        return "ニュースを追加しました!";
+    }
+}

--- a/myProject202411122354/src/main/resources/static/js/admin-news.js
+++ b/myProject202411122354/src/main/resources/static/js/admin-news.js
@@ -1,0 +1,61 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const newsForm = document.getElementById('newsForm');
+    const newsList = document.getElementById('news-list');
+
+    // フォーム送信処理
+    newsForm.addEventListener('submit', (event) => {
+        event.preventDefault();
+
+        const formData = {
+            date: document.getElementById('date').value,
+            content: document.getElementById('content').value,
+            details: document.getElementById('details').value,
+            imageUrl: document.getElementById('imageUrl').value,
+            link: document.getElementById('link').value,
+        };
+
+        fetch('/admin/news/add', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(formData),
+        })
+            .then((response) => response.text())
+            .then((data) => {
+                alert(data);
+                fetchNews(); // ニュースを再取得して更新
+            })
+            .catch((error) => console.error('Error:', error));
+    });
+
+    // ニュースデータを取得して表示
+    function fetchNews() {
+        fetch('/api/news')
+            .then((response) => {
+                if (!response.ok) {
+                    throw new Error('Failed to fetch news updates');
+                }
+                return response.json();
+            })
+            .then((data) => {
+                newsList.innerHTML = '';
+                data.forEach((news) => {
+                    const newsHTML = `
+                        <div class="news-item">
+                            <p><strong>日付:</strong> ${news.date}</p>
+                            <p><strong>コンテンツ:</strong> ${news.content}</p>
+                            <p><strong>リンク:</strong> ${news.link || 'なし'}</p>
+                            <p><strong>画像URL:</strong> ${news.imageUrl || 'なし'}</p>
+                            <p><strong>詳細:</strong> ${news.details || 'なし'}</p>
+                        </div>
+                    `;
+                    newsList.insertAdjacentHTML('beforeend', newsHTML);
+                });
+            })
+            .catch((error) => console.error('Error fetching news:', error));
+    }
+
+    // 初期ロード時にニュースを取得
+    fetchNews();
+});

--- a/myProject202411122354/src/main/resources/templates/admin-news.html
+++ b/myProject202411122354/src/main/resources/templates/admin-news.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>管理者用ニュース追加</title>
+</head>
+<body>
+    <h1>ニュースを追加</h1>
+    <form id="newsForm">
+        <label for="date">日付:</label>
+        <input type="date" id="date" name="date" required><br>
+        <label for="content">内容:</label>
+        <textarea id="content" name="content" required></textarea><br>
+        <label for="details">詳細:</label>
+        <textarea id="details" name="details"></textarea><br>
+        <label for="imageUrl">画像URL (カンマ区切り):</label>
+        <input type="text" id="imageUrl" name="imageUrl"><br>
+        <label for="link">リンク:</label>
+        <input type="text" id="link" name="link"><br>
+        <button type="submit">ニュースを追加</button>
+    </form>
+    <h2>既存ニュース一覧</h2>
+    <div id="news-list">
+        <!-- JavaScriptでニュースデータを埋め込み -->
+    </div>
+    <script src="/js/admin-news.js"></script>
+</body>
+</html>


### PR DESCRIPTION
- 管理者専用ページ (/admin/news) を作成
- ニュース追加用フォームを提供 (日付、内容、詳細、画像URL、リンク)
- Spring Security を更新して ROLE_ADMIN のみアクセス可能に設定
- RESTエンドポイント /admin/news/add を実装し、ニュースをデータベースに保存する機能を追加
- フロントエンドフォームからニュースデータを送信できるよう JavaScript を実装
※本番環境のnewsのモーダル内の画像の取り回し だけは手動で開発の/imagesに投入して本番へ転送（あとはいつものデプロイの手順）しないと実現しない！あくまで80%くらいの雛型が作成されるイメージ100%までは手動でする。