### PR TITLE
Feature/national league west

### DIFF
--- a/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/config/AppConfig.java
+++ b/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/config/AppConfig.java
@@ -1,0 +1,14 @@
+package com.example.dodgersshoheiapp.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/config/SecurityConfig.java
+++ b/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/config/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
                                 "/comments", "/links", "/auth/userinfo", "/api/visitorCounter/**", "/api/proud/**",
                                 "/proud", "/stats", "/api/stats", "/notifications/subscribe", "/notifications/send",
                                 "/icon.png", "/sw.js", "/notifications/**", "/subscriptions/**",
-                                "/notifications/comments", "/api/news", "/home")
+                                "/notifications/comments", "/api/news", "/api/dodgers/standings", "/home")
                         .permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN") // 管理者専用エンドポイントを保護
                         .anyRequest().authenticated())

--- a/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/controller/DodgersStandingsController.java
+++ b/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/controller/DodgersStandingsController.java
@@ -1,0 +1,23 @@
+package com.example.dodgersshoheiapp.controller;
+
+import com.example.dodgersshoheiapp.service.DodgersStandingsService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/dodgers/standings")
+public class DodgersStandingsController {
+
+    private final DodgersStandingsService standingsService;
+
+    public DodgersStandingsController(DodgersStandingsService standingsService) {
+        this.standingsService = standingsService;
+    }
+
+    @GetMapping
+    public List<Map<String, Object>> getStandings() {
+        return standingsService.getDodgersStandings();
+    }
+}

--- a/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/controller/DodgersStandingsController.java
+++ b/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/controller/DodgersStandingsController.java
@@ -9,7 +9,6 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/dodgers/standings")
 public class DodgersStandingsController {
-
     private final DodgersStandingsService standingsService;
 
     public DodgersStandingsController(DodgersStandingsService standingsService) {
@@ -17,7 +16,7 @@ public class DodgersStandingsController {
     }
 
     @GetMapping
-    public List<Map<String, Object>> getStandings() {
-        return standingsService.getDodgersStandings();
+    public Map<String, List<Map<String, Object>>> getStandings() {
+        return standingsService.getDodgersStandings(); // ← Map をそのまま返すように修正
     }
 }

--- a/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/controller/DodgersStandingsController.java
+++ b/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/controller/DodgersStandingsController.java
@@ -3,8 +3,8 @@ package com.example.dodgersshoheiapp.controller;
 import com.example.dodgersshoheiapp.service.DodgersStandingsService;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.Map;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/dodgers/standings")
@@ -16,7 +16,7 @@ public class DodgersStandingsController {
     }
 
     @GetMapping
-    public Map<String, List<Map<String, Object>>> getStandings() {
-        return standingsService.getDodgersStandings(); // ← Map をそのまま返すように修正
+    public Map<String, List<Map<String, Object>>> getMLBStandings() {
+        return standingsService.getMLBStandings();
     }
 }

--- a/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/service/DodgersStandingsService.java
+++ b/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/service/DodgersStandingsService.java
@@ -1,0 +1,56 @@
+package com.example.dodgersshoheiapp.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import java.util.*;
+
+@Service
+public class DodgersStandingsService {
+    // レギュラーシーズン
+    private static final String API_URL = "https://statsapi.mlb.com/api/v1/standings?leagueId=104&division=203&season=2024&standingsTypes=regularSeason";
+
+    // 他のモードの URL (切り替え用)
+    // private static final String SPRING_TRAINING_API_URL =
+    // "https://statsapi.mlb.com/api/v1/standings?leagueId=104&division=203&season=2024&standingsTypes=springTraining";
+    // private static final String POSTSEASON_API_URL =
+    // "https://statsapi.mlb.com/api/v1/standings?leagueId=104&division=203&season=2024&standingsTypes=postseason";
+    // private static final String DIVISION_SERIES_API_URL =
+    // "https://statsapi.mlb.com/api/v1/standings?leagueId=104&division=203&season=2024&standingsTypes=divisionSeries";
+    // private static final String WORLD_SERIES_API_URL =
+    // "https://statsapi.mlb.com/api/v1/standings?leagueId=104&division=203&season=2024&standingsTypes=worldSeries";
+
+    private final RestTemplate restTemplate;
+
+    public DodgersStandingsService(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    public List<Map<String, Object>> getDodgersStandings() {
+        Map<String, Object> response = restTemplate.getForObject(API_URL, Map.class);
+        List<Map<String, Object>> records = (List<Map<String, Object>>) response.get("records");
+
+        List<Map<String, Object>> standings = new ArrayList<>();
+
+        if (records != null) {
+            for (Map<String, Object> record : records) {
+                List<Map<String, Object>> teams = (List<Map<String, Object>>) record.get("teamRecords");
+
+                for (Map<String, Object> team : teams) {
+                    Map<String, Object> teamData = new HashMap<>();
+                    Map<String, Object> teamInfo = (Map<String, Object>) team.get("team");
+
+                    teamData.put("rank", team.get("divisionRank"));
+                    teamData.put("name", teamInfo.get("name"));
+                    teamData.put("wins", team.get("wins"));
+                    teamData.put("losses", team.get("losses"));
+                    teamData.put("winPercentage", team.get("winPercentage"));
+                    teamData.put("gamesBack", team.get("gamesBack"));
+                    teamData.put("teamId", teamInfo.get("id")); // チームロゴ取得用
+
+                    standings.add(teamData);
+                }
+            }
+        }
+        return standings;
+    }
+}

--- a/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/service/DodgersStandingsService.java
+++ b/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/service/DodgersStandingsService.java
@@ -2,13 +2,12 @@ package com.example.dodgersshoheiapp.service;
 
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
+
 import java.util.*;
 
 @Service
 public class DodgersStandingsService {
-    // レギュラーシーズン
-    private static final String API_URL = "https://statsapi.mlb.com/api/v1/standings?leagueId=104&division=203&season=2024&standingsTypes=regularSeason";
-
+    private static final String API_URL = "https://statsapi.mlb.com/api/v1/standings?leagueId=103,104&season=2024&standingsTypes=regularSeason";
     // 他のモードの URL (切り替え用)
     // private static final String SPRING_TRAINING_API_URL =
     // "https://statsapi.mlb.com/api/v1/standings?leagueId=104&division=203&season=2024&standingsTypes=springTraining";
@@ -25,11 +24,20 @@ public class DodgersStandingsService {
         this.restTemplate = restTemplate;
     }
 
-    public List<Map<String, Object>> getDodgersStandings() {
+    public Map<String, List<Map<String, Object>>> getDodgersStandings() {
         Map<String, Object> response = restTemplate.getForObject(API_URL, Map.class);
         List<Map<String, Object>> records = (List<Map<String, Object>>) response.get("records");
 
-        List<Map<String, Object>> standings = new ArrayList<>();
+        // 地区ごとのデータを格納
+        Map<String, List<Map<String, Object>>> standingsByDivision = new LinkedHashMap<>();
+        standingsByDivision.put("NL 東地区", new ArrayList<>());
+        standingsByDivision.put("NL 中地区", new ArrayList<>());
+        standingsByDivision.put("NL 西地区", new ArrayList<>());
+
+        // 地区ごとの teamId リスト
+        Set<Integer> eastTeams = Set.of(143, 144, 121, 120, 146);
+        Set<Integer> centralTeams = Set.of(158, 112, 138, 113, 134);
+        Set<Integer> westTeams = Set.of(119, 135, 109, 137, 115);
 
         if (records != null) {
             for (Map<String, Object> record : records) {
@@ -39,18 +47,26 @@ public class DodgersStandingsService {
                     Map<String, Object> teamData = new HashMap<>();
                     Map<String, Object> teamInfo = (Map<String, Object>) team.get("team");
 
+                    int teamId = (int) teamInfo.get("id");
+
                     teamData.put("rank", team.get("divisionRank"));
                     teamData.put("name", teamInfo.get("name"));
                     teamData.put("wins", team.get("wins"));
                     teamData.put("losses", team.get("losses"));
                     teamData.put("winPercentage", team.get("winPercentage"));
                     teamData.put("gamesBack", team.get("gamesBack"));
-                    teamData.put("teamId", teamInfo.get("id")); // チームロゴ取得用
+                    teamData.put("teamId", teamId);
 
-                    standings.add(teamData);
+                    if (eastTeams.contains(teamId)) {
+                        standingsByDivision.get("NL 東地区").add(teamData);
+                    } else if (centralTeams.contains(teamId)) {
+                        standingsByDivision.get("NL 中地区").add(teamData);
+                    } else if (westTeams.contains(teamId)) {
+                        standingsByDivision.get("NL 西地区").add(teamData);
+                    }
                 }
             }
         }
-        return standings;
+        return standingsByDivision;
     }
 }

--- a/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/service/DodgersStandingsService.java
+++ b/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/service/DodgersStandingsService.java
@@ -2,12 +2,13 @@ package com.example.dodgersshoheiapp.service;
 
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
-
 import java.util.*;
 
 @Service
 public class DodgersStandingsService {
-    private static final String API_URL = "https://statsapi.mlb.com/api/v1/standings?leagueId=103,104&season=2024&standingsTypes=regularSeason";
+    private static final String API_URL_NL = "https://statsapi.mlb.com/api/v1/standings?leagueId=104&season=2024&standingsTypes=regularSeason";
+    private static final String API_URL_AL = "https://statsapi.mlb.com/api/v1/standings?leagueId=103&season=2024&standingsTypes=regularSeason";
+
     // 他のモードの URL (切り替え用)
     // private static final String SPRING_TRAINING_API_URL =
     // "https://statsapi.mlb.com/api/v1/standings?leagueId=104&division=203&season=2024&standingsTypes=springTraining";
@@ -24,49 +25,66 @@ public class DodgersStandingsService {
         this.restTemplate = restTemplate;
     }
 
-    public Map<String, List<Map<String, Object>>> getDodgersStandings() {
-        Map<String, Object> response = restTemplate.getForObject(API_URL, Map.class);
+    public Map<String, List<Map<String, Object>>> getMLBStandings() {
+        Map<String, List<Map<String, Object>>> standingsByLeague = new LinkedHashMap<>();
+
+        // NL & AL のデータ取得
+        processLeagueData(API_URL_NL, standingsByLeague, "NL");
+        processLeagueData(API_URL_AL, standingsByLeague, "AL");
+
+        return standingsByLeague;
+    }
+
+    private void processLeagueData(String apiUrl, Map<String, List<Map<String, Object>>> standingsByLeague,
+            String leaguePrefix) {
+        Map<String, Object> response = restTemplate.getForObject(apiUrl, Map.class);
         List<Map<String, Object>> records = (List<Map<String, Object>>) response.get("records");
 
-        // 地区ごとのデータを格納
-        Map<String, List<Map<String, Object>>> standingsByDivision = new LinkedHashMap<>();
-        standingsByDivision.put("NL 東地区", new ArrayList<>());
-        standingsByDivision.put("NL 中地区", new ArrayList<>());
-        standingsByDivision.put("NL 西地区", new ArrayList<>());
+        if (records == null)
+            return;
 
-        // 地区ごとの teamId リスト
-        Set<Integer> eastTeams = Set.of(143, 144, 121, 120, 146);
-        Set<Integer> centralTeams = Set.of(158, 112, 138, 113, 134);
-        Set<Integer> westTeams = Set.of(119, 135, 109, 137, 115);
+        // **修正：チームIDで正しく地区を振り分ける**
+        Set<Integer> eastTeams = leaguePrefix.equals("NL")
+                ? Set.of(144, 146, 121, 143, 120) // **NL 東地区**
+                : Set.of(110, 111, 147, 139, 141); // **AL 東地区**
 
-        if (records != null) {
-            for (Map<String, Object> record : records) {
-                List<Map<String, Object>> teams = (List<Map<String, Object>>) record.get("teamRecords");
+        Set<Integer> centralTeams = leaguePrefix.equals("NL")
+                ? Set.of(112, 113, 158, 134, 138) // **NL 中地区**
+                : Set.of(145, 114, 116, 118, 142); // **AL 中地区（修正済み！）**
 
-                for (Map<String, Object> team : teams) {
-                    Map<String, Object> teamData = new HashMap<>();
-                    Map<String, Object> teamInfo = (Map<String, Object>) team.get("team");
+        Set<Integer> westTeams = leaguePrefix.equals("NL")
+                ? Set.of(109, 115, 119, 135, 137) // **NL 西地区**
+                : Set.of(117, 108, 133, 136, 140); // **AL 西地区（Astros 修正済み！）**
 
-                    int teamId = (int) teamInfo.get("id");
+        standingsByLeague.put(leaguePrefix + " 東地区", new ArrayList<>());
+        standingsByLeague.put(leaguePrefix + " 中地区", new ArrayList<>());
+        standingsByLeague.put(leaguePrefix + " 西地区", new ArrayList<>());
 
-                    teamData.put("rank", team.get("divisionRank"));
-                    teamData.put("name", teamInfo.get("name"));
-                    teamData.put("wins", team.get("wins"));
-                    teamData.put("losses", team.get("losses"));
-                    teamData.put("winPercentage", team.get("winPercentage"));
-                    teamData.put("gamesBack", team.get("gamesBack"));
-                    teamData.put("teamId", teamId);
+        for (Map<String, Object> record : records) {
+            List<Map<String, Object>> teams = (List<Map<String, Object>>) record.get("teamRecords");
 
-                    if (eastTeams.contains(teamId)) {
-                        standingsByDivision.get("NL 東地区").add(teamData);
-                    } else if (centralTeams.contains(teamId)) {
-                        standingsByDivision.get("NL 中地区").add(teamData);
-                    } else if (westTeams.contains(teamId)) {
-                        standingsByDivision.get("NL 西地区").add(teamData);
-                    }
+            for (Map<String, Object> team : teams) {
+                Map<String, Object> teamData = new HashMap<>();
+                Map<String, Object> teamInfo = (Map<String, Object>) team.get("team");
+
+                int teamId = (int) teamInfo.get("id");
+
+                teamData.put("rank", team.get("divisionRank"));
+                teamData.put("name", teamInfo.get("name"));
+                teamData.put("wins", team.get("wins"));
+                teamData.put("losses", team.get("losses"));
+                teamData.put("winPercentage", team.get("winPercentage"));
+                teamData.put("gamesBack", team.get("gamesBack"));
+                teamData.put("teamId", teamId);
+
+                if (eastTeams.contains(teamId)) {
+                    standingsByLeague.get(leaguePrefix + " 東地区").add(teamData);
+                } else if (centralTeams.contains(teamId)) {
+                    standingsByLeague.get(leaguePrefix + " 中地区").add(teamData);
+                } else if (westTeams.contains(teamId)) {
+                    standingsByLeague.get(leaguePrefix + " 西地区").add(teamData);
                 }
             }
         }
-        return standingsByDivision;
     }
 }

--- a/myProject202411122354/src/main/resources/static/css/Douga.css
+++ b/myProject202411122354/src/main/resources/static/css/Douga.css
@@ -60,7 +60,7 @@
 /* Responsive video container */
 #douga-container-3 {
     position: relative;
-    width: 225%;
+    width: 158%;
     height: 7em !important;
     padding-top: 70.25%;
     background-color: #000;

--- a/myProject202411122354/src/main/resources/static/css/style.css
+++ b/myProject202411122354/src/main/resources/static/css/style.css
@@ -577,16 +577,16 @@ a:hover {
 }
 
 #tooltip-proud {
-    top: 318em;
+    top: 314em;
     left: 12em;
 }
 
 #tooltip-chat {
-    top: 339em;
+    top: 334em;
     left: 5em;
 }
 #tooltip-link {
-    top: 366em;
+    top: 362em;
     left: 10em;
 }
 
@@ -1149,16 +1149,16 @@ body {
 }
 
 #tooltip-proud {
-    top: 318em;
+    top: 314em;
     left: 12em;
 }
 
 #tooltip-chat {
-    top: 339em;
+    top: 334em;
     left: 5em;
 }
 #tooltip-link {
-    top: 366em;
+    top: 362em;
     left: 10em;
 }
 
@@ -1804,16 +1804,16 @@ body {
 }
 
 #tooltip-proud {
-    top: 318em;
+    top: 314em;
     left: 12em;
 }
 
 #tooltip-chat {
-    top: 339em;
+    top: 334em;
     left: 5em;
 }
 #tooltip-link {
-    top: 366em;
+    top: 362em;
     left: 10em;
 }
 

--- a/myProject202411122354/src/main/resources/static/css/style.css
+++ b/myProject202411122354/src/main/resources/static/css/style.css
@@ -577,15 +577,17 @@ a:hover {
 }
 
 #tooltip-proud {
-    top: 278em;
+    top: 318em;
+    left: 12em;
 }
+
 #tooltip-chat {
-    top: 299em;
-    left: 9em;
+    top: 339em;
+    left: 5em;
 }
 #tooltip-link {
-    top: 326em;
-    left: 14em;
+    top: 366em;
+    left: 10em;
 }
 
 /* 閉じるボタン */
@@ -716,6 +718,77 @@ a:hover {
 }
 
 /* end======== ニュース/トピック/サイト最新情報 ======== */
+
+
+/* start======== MLB 地区別順位表 ======== */
+
+/* コンテナの基本設定 */
+.standings-container {
+    width: 50%;
+    overflow: hidden;
+    position: relative;
+}
+
+/* 各地区のスライドを独立させる */
+.standings-wrapper {
+    display: flex;
+    transition: transform 0.4s ease-in-out;
+    width: 100%; /* 3スライド分 */
+}
+
+.standings-slide {
+    width: 100%;
+    flex-shrink: 0;
+    text-align: center;
+}
+
+/* テーブルデザイン */
+.styled-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 10px auto;
+    font-size: 16px;
+    text-align: center;
+}
+
+.styled-table thead {
+    background-color: #003366;
+    color: white;
+}
+
+.styled-table th, .styled-table td {
+    padding: 8px 12px;
+    border: 1px solid #ddd;
+}
+
+.styled-table tbody tr:nth-child(even) {
+    background-color: #f2f2f2;
+}
+
+/* ボタンデザイン */
+#prevBtn, #nextBtn {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    background: rgba(0, 0, 0, 0.5);
+    color: white;
+    border: none;
+    padding: 10px;
+    cursor: pointer;
+    font-size: 20px;
+}
+
+#prevBtn { left: 10px; }
+#nextBtn { right: 10px; }
+
+/* スマホ対応 */
+@media screen and (max-width: 768px) {
+    .styled-table {
+        font-size: 14px;
+    }
+}
+/* end ========  MLB 地区別順位表 ======== */
+
 
 
 
@@ -1076,15 +1149,17 @@ body {
 }
 
 #tooltip-proud {
-    top: 278em;
+    top: 318em;
+    left: 12em;
 }
+
 #tooltip-chat {
-    top: 299em;
-    left: 9em;
+    top: 339em;
+    left: 5em;
 }
 #tooltip-link {
-    top: 326em;
-    left: 14em;
+    top: 366em;
+    left: 10em;
 }
 
 /* 閉じるボタン */
@@ -1215,6 +1290,80 @@ body {
 
 
 /* end======== ニュース/トピック/サイト最新情報 ========768px */
+
+
+
+
+
+/* start======== MLB 地区別順位表(max-width: 768px) ======== */
+
+/* コンテナの基本設定 */
+.standings-container {
+    width: 94%;
+    overflow: hidden;
+    position: relative;
+}
+
+/* 各地区のスライドを独立させる */
+.standings-wrapper {
+    display: flex;
+    transition: transform 0.4s ease-in-out;
+    width: 100%; /* 3スライド分 */
+}
+
+.standings-slide {
+    width: 100%;
+    flex-shrink: 0;
+    text-align: center;
+}
+
+/* テーブルデザイン */
+.styled-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 10px auto;
+    font-size: 16px;
+    text-align: center;
+}
+
+.styled-table thead {
+    background-color: #003366;
+    color: white;
+}
+
+.styled-table th, .styled-table td {
+    padding: 8px 12px;
+    border: 1px solid #ddd;
+}
+
+.styled-table tbody tr:nth-child(even) {
+    background-color: #f2f2f2;
+}
+
+/* ボタンデザイン */
+#prevBtn, #nextBtn {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    background: rgba(0, 0, 0, 0.5);
+    color: white;
+    border: none;
+    padding: 10px;
+    cursor: pointer;
+    font-size: 20px;
+}
+
+#prevBtn { left: 10px; }
+#nextBtn { right: 10px; }
+
+/* スマホ対応 */
+@media screen and (max-width: 768px) {
+    .styled-table {
+        font-size: 14px;
+    }
+}
+/* end ========  MLB 地区別順位表(max-width: 768px) ======== */
+
 
 
 
@@ -1655,15 +1804,16 @@ body {
 }
 
 #tooltip-proud {
-    top: 271em;
+    top: 318em;
     left: 12em;
 }
+
 #tooltip-chat {
-    top: 292em;
-    left: 4em;
+    top: 339em;
+    left: 5em;
 }
 #tooltip-link {
-    top: 320em;
+    top: 366em;
     left: 10em;
 }
 
@@ -1833,6 +1983,74 @@ body {
 
 
 
+/* start======== MLB 地区別順位表(max-width: 430px) ======== */
+
+/* コンテナの基本設定 */
+.standings-container {
+    width: 94%;
+    overflow: hidden;
+    position: relative;
+}
+
+/* 各地区のスライドを独立させる */
+.standings-wrapper {
+    display: flex;
+    transition: transform 0.4s ease-in-out;
+    width: 100%; /* 3スライド分 */
+}
+
+.standings-slide {
+    width: 100%;
+    flex-shrink: 0;
+    text-align: center;
+}
+
+/* テーブルデザイン */
+.styled-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 10px auto;
+    font-size: 16px;
+    text-align: center;
+}
+
+.styled-table thead {
+    background-color: #003366;
+    color: white;
+}
+
+.styled-table th, .styled-table td {
+    padding: 8px 12px;
+    border: 1px solid #ddd;
+}
+
+.styled-table tbody tr:nth-child(even) {
+    background-color: #f2f2f2;
+}
+
+/* ボタンデザイン */
+#prevBtn, #nextBtn {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    background: rgba(0, 0, 0, 0.5);
+    color: white;
+    border: none;
+    padding: 10px;
+    cursor: pointer;
+    font-size: 20px;
+}
+
+#prevBtn { left: 10px; }
+#nextBtn { right: 10px; }
+
+/* スマホ対応 */
+@media screen and (max-width: 768px) {
+    .styled-table {
+        font-size: 14px;
+    }
+}
+/* end ========  MLB 地区別順位表(max-width: 430px) ======== */
 
 
 

--- a/myProject202411122354/src/main/resources/templates/home.html
+++ b/myProject202411122354/src/main/resources/templates/home.html
@@ -110,51 +110,139 @@ document.addEventListener('DOMContentLoaded', function () {
 
 
 
-<!-- start NL西地区 順位表 -->
-    <div id="standings-table">
-        <h2>🏆 NL西地区 順位表</h2>
-        <table>
-            <thead>
-                <tr>
-                    <th>順位</th>
-                    <th>チーム</th>
-                    <th>勝</th>
-                    <th>負</th>
-                    <th>勝率</th>
-                    <th>ゲーム差</th>
-                </tr>
-            </thead>
-            <tbody id="standings-body"></tbody>
-        </table>
+<!-- MLB 地区別順位表 (スワイプ対応) -->
+<div class="standings-container">
+    <div class="standings-wrapper">
+        <!-- NL 東地区 -->
+        <div class="standings-slide">
+            <h3>NL 東地区</h3>
+            <table class="styled-table">
+                <thead>
+                    <tr>
+                        <th>順位</th>
+                        <th>チーム</th>
+                        <th>勝</th>
+                        <th>負</th>
+                        <th>勝率</th>
+                        <th>ゲーム差</th>
+                    </tr>
+                </thead>
+                <tbody id="nl-east-body"></tbody>
+            </table>
+        </div>
+
+        <!-- NL 中地区 -->
+        <div class="standings-slide">
+            <h3>NL 中地区</h3>
+            <table class="styled-table">
+                <thead>
+                    <tr>
+                        <th>順位</th>
+                        <th>チーム</th>
+                        <th>勝</th>
+                        <th>負</th>
+                        <th>勝率</th>
+                        <th>ゲーム差</th>
+                    </tr>
+                </thead>
+                <tbody id="nl-central-body"></tbody>
+            </table>
+        </div>
+
+        <!-- NL 西地区 -->
+        <div class="standings-slide">
+            <h3>NL 西地区</h3>
+            <table class="styled-table">
+                <thead>
+                    <tr>
+                        <th>順位</th>
+                        <th>チーム</th>
+                        <th>勝</th>
+                        <th>負</th>
+                        <th>勝率</th>
+                        <th>ゲーム差</th>
+                    </tr>
+                </thead>
+                <tbody id="nl-west-body"></tbody>
+            </table>
+        </div>
     </div>
+</div>
 
-    <script>
-        document.addEventListener("DOMContentLoaded", function () {
-            fetch("/api/dodgers/standings")
-                .then(response => response.json())
-                .then(data => {
-                    let tbody = document.getElementById("standings-body");
-                    tbody.innerHTML = "";
+<!-- 左右のナビゲーションボタン -->
+<button id="prevBtn">◀</button>
+<button id="nextBtn">▶</button>
 
+<script>
+    document.addEventListener("DOMContentLoaded", function () {
+        let currentIndex = 2; // デフォルトを NL 西地区（index: 2）に設定
+        const slides = document.querySelectorAll(".standings-slide");
+        const wrapper = document.querySelector(".standings-wrapper");
+
+        function updateSlide() {
+            wrapper.style.transform = `translateX(-${currentIndex * 100}%)`;
+        }
+
+        // 初期表示を NL 西地区に設定
+        updateSlide();
+
+        document.getElementById("nextBtn").addEventListener("click", function () {
+            currentIndex = (currentIndex + 1) % slides.length;
+            updateSlide();
+        });
+
+        document.getElementById("prevBtn").addEventListener("click", function () {
+            currentIndex = (currentIndex - 1 + slides.length) % slides.length;
+            updateSlide();
+        });
+
+        // スワイプ対応
+        let startX = 0;
+        wrapper.addEventListener("touchstart", (e) => {
+            startX = e.touches[0].clientX;
+        });
+
+        wrapper.addEventListener("touchend", (e) => {
+            let endX = e.changedTouches[0].clientX;
+            if (startX - endX > 50) { 
+                currentIndex = (currentIndex + 1) % slides.length;
+            } else if (endX - startX > 50) {
+                currentIndex = (currentIndex - 1 + slides.length) % slides.length;
+            }
+            updateSlide();
+        });
+
+        // データを取得して各地区に挿入
+        fetch("/api/dodgers/standings")
+            .then(response => response.json())
+            .then(data => {
+                function populateTable(data, tbody) {
                     data.forEach(team => {
                         let row = document.createElement("tr");
                         let trophy = team.rank === "1" ? "🏆" : "";
-                        
+                        let winPercentage = team.winPercentage !== null 
+                            ? parseFloat(team.winPercentage).toFixed(3) 
+                            : (team.wins / (team.wins + team.losses)).toFixed(3);
+
                         row.innerHTML = `
                             <td>${team.rank}️⃣ ${trophy}</td>
                             <td><img src="https://www.mlbstatic.com/team-logos/${team.teamId}.svg" width="30"> ${team.name}</td>
                             <td>${team.wins}</td>
                             <td>${team.losses}</td>
-                            <td>${team.winPercentage}</td>
+                            <td>${winPercentage}</td>
                             <td>${team.gamesBack}</td>
                         `;
                         tbody.appendChild(row);
                     });
-                })
-                .catch(error => console.error("Error loading standings:", error));
-        });
-    </script>
-<!-- End NL西地区 順位表 -->
+                }
+
+                populateTable(data["NL 東地区"], document.getElementById("nl-east-body"));
+                populateTable(data["NL 中地区"], document.getElementById("nl-central-body"));
+                populateTable(data["NL 西地区"], document.getElementById("nl-west-body"));
+            })
+            .catch(error => console.error("Error loading standings:", error));
+    });
+</script>
 
 
 
@@ -178,12 +266,12 @@ document.addEventListener('DOMContentLoaded', function () {
                 <!-- 打者成績セクション -->
                 <div id="hitter-stats">
                     <div id="HitterStats-1">Hitter Stats</div>
-                    <div><strong>Games:</strong> <span id="gamesPlayed"></span></div>
-                    <div><strong>Average (AVG):</strong> <span id="avg"></span></div>
-                    <div><strong>Home Runs:</strong> <span id="homeRuns"></span></div>
-                    <div><strong>Stolen Bases:</strong> <span id="stolenBases"></span></div>
-                    <div><strong>RBIs:</strong> <span id="rbi"></span></div>
-                    <div><strong>OPS:</strong> <span id="ops"></span></div>
+                    <div><strong>出場数:</strong> <span id="gamesPlayed"></span></div>
+                    <div><strong>打率:　</strong> <span id="avg"></span></div>
+                    <div><strong>本塁打:</strong> <span id="homeRuns"></span></div>
+                    <div><strong>盗塁:　</strong> <span id="stolenBases"></span></div>
+                    <div><strong>打点:　</strong> <span id="rbi"></span></div>
+                    <div><strong>OPS:　</strong> <span id="ops"></span></div>
                 </div>
             </div>
             <img src="/images/trimmin'-ohtani_swinggin'.png" alt="背景画像1" class="home-image6">
@@ -204,11 +292,11 @@ document.addEventListener('DOMContentLoaded', function () {
                 <!-- 投手成績セクション -->
                 <div id="pitcher-stats">
                     <div id="pitcher-stats-2">Pitcher Stats</div>
-                    <div id="pitcher-stats-2_child"><strong>Games:</strong> <span id="pitcherGamesPlayed"></span></div>
-                    <div id="pitcher-stats-2_child"><strong>Wins:</strong> <span id="wins"></span></div>
-                    <div id="pitcher-stats-2_child"><strong>Losses:</strong> <span id="losses"></span></div>
-                    <div id="pitcher-stats-2_child"><strong>ERA:</strong> <span id="era"></span></div>
-                    <div id="pitcher-stats-2_child"><strong>Strikeouts:</strong> <span id="strikeOuts"></span></div>
+                    <div id="pitcher-stats-2_child"><strong>投球日:　</strong> <span id="pitcherGamesPlayed"></span></div>
+                    <div id="pitcher-stats-2_child"><strong>勝ち:　　</strong> <span id="wins"></span></div>
+                    <div id="pitcher-stats-2_child"><strong>負け:　　</strong> <span id="losses"></span></div>
+                    <div id="pitcher-stats-2_child"><strong>防御率:　</strong> <span id="era"></span></div>
+                    <div id="pitcher-stats-2_child"><strong>奪三振:　</strong> <span id="strikeOuts"></span></div>
                 </div>
             </div>
             <img src="/images/LAD投げる大谷翔平-removebg-preview.png" alt="背景画像1" class="home-image9">

--- a/myProject202411122354/src/main/resources/templates/home.html
+++ b/myProject202411122354/src/main/resources/templates/home.html
@@ -110,139 +110,109 @@ document.addEventListener('DOMContentLoaded', function () {
 
 
 
-<!-- MLB 地区別順位表 (スワイプ対応) -->
+<!--start MLB 地区別順位表 (スワイプ対応) -->
 <div class="standings-container">
     <div class="standings-wrapper">
-        <!-- NL 東地区 -->
-        <div class="standings-slide">
-            <h3>NL 東地区</h3>
-            <table class="styled-table">
-                <thead>
-                    <tr>
-                        <th>順位</th>
-                        <th>チーム</th>
-                        <th>勝</th>
-                        <th>負</th>
-                        <th>勝率</th>
-                        <th>ゲーム差</th>
-                    </tr>
-                </thead>
-                <tbody id="nl-east-body"></tbody>
-            </table>
-        </div>
-
-        <!-- NL 中地区 -->
-        <div class="standings-slide">
-            <h3>NL 中地区</h3>
-            <table class="styled-table">
-                <thead>
-                    <tr>
-                        <th>順位</th>
-                        <th>チーム</th>
-                        <th>勝</th>
-                        <th>負</th>
-                        <th>勝率</th>
-                        <th>ゲーム差</th>
-                    </tr>
-                </thead>
-                <tbody id="nl-central-body"></tbody>
-            </table>
-        </div>
-
-        <!-- NL 西地区 -->
-        <div class="standings-slide">
-            <h3>NL 西地区</h3>
-            <table class="styled-table">
-                <thead>
-                    <tr>
-                        <th>順位</th>
-                        <th>チーム</th>
-                        <th>勝</th>
-                        <th>負</th>
-                        <th>勝率</th>
-                        <th>ゲーム差</th>
-                    </tr>
-                </thead>
-                <tbody id="nl-west-body"></tbody>
-            </table>
-        </div>
+        <div class="standings-slide" id="nl-west"><h3>NL 西地区</h3><table class="styled-table"><thead>...</thead><tbody id="nl-west-body"></tbody></table></div>
+        <div class="standings-slide" id="nl-central"><h3>NL 中地区</h3><table class="styled-table"><thead>...</thead><tbody id="nl-central-body"></tbody></table></div>
+        <div class="standings-slide" id="nl-east"><h3>NL 東地区</h3><table class="styled-table"><thead>...</thead><tbody id="nl-east-body"></tbody></table></div>
+        <div class="standings-slide" id="al-west"><h3>AL 西地区</h3><table class="styled-table"><thead>...</thead><tbody id="al-west-body"></tbody></table></div>
+        <div class="standings-slide" id="al-central"><h3>AL 中地区</h3><table class="styled-table"><thead>...</thead><tbody id="al-central-body"></tbody></table></div>
+        <div class="standings-slide" id="al-east"><h3>AL 東地区</h3><table class="styled-table"><thead>...</thead><tbody id="al-east-body"></tbody></table></div>
     </div>
 </div>
 
-<!-- 左右のナビゲーションボタン -->
 <button id="prevBtn">◀</button>
 <button id="nextBtn">▶</button>
 
 <script>
-    document.addEventListener("DOMContentLoaded", function () {
-        let currentIndex = 2; // デフォルトを NL 西地区（index: 2）に設定
-        const slides = document.querySelectorAll(".standings-slide");
-        const wrapper = document.querySelector(".standings-wrapper");
+document.addEventListener("DOMContentLoaded", function () {
+    let currentIndex = 0; // 🚀 デフォルトを NL 西地区に設定
+    const slides = document.querySelectorAll(".standings-slide");
+    const wrapper = document.querySelector(".standings-wrapper");
 
-        function updateSlide() {
-            wrapper.style.transform = `translateX(-${currentIndex * 100}%)`;
-        }
+    function updateSlide() {
+        wrapper.style.transform = `translateX(-${currentIndex * 100}%)`;
+    }
 
-        // 初期表示を NL 西地区に設定
+    // 🚀 ページロード時に NL 西地区を表示
+    updateSlide();
+
+    document.getElementById("nextBtn").addEventListener("click", function () {
+        currentIndex = (currentIndex + 1) % slides.length;
         updateSlide();
-
-        document.getElementById("nextBtn").addEventListener("click", function () {
-            currentIndex = (currentIndex + 1) % slides.length;
-            updateSlide();
-        });
-
-        document.getElementById("prevBtn").addEventListener("click", function () {
-            currentIndex = (currentIndex - 1 + slides.length) % slides.length;
-            updateSlide();
-        });
-
-        // スワイプ対応
-        let startX = 0;
-        wrapper.addEventListener("touchstart", (e) => {
-            startX = e.touches[0].clientX;
-        });
-
-        wrapper.addEventListener("touchend", (e) => {
-            let endX = e.changedTouches[0].clientX;
-            if (startX - endX > 50) { 
-                currentIndex = (currentIndex + 1) % slides.length;
-            } else if (endX - startX > 50) {
-                currentIndex = (currentIndex - 1 + slides.length) % slides.length;
-            }
-            updateSlide();
-        });
-
-        // データを取得して各地区に挿入
-        fetch("/api/dodgers/standings")
-            .then(response => response.json())
-            .then(data => {
-                function populateTable(data, tbody) {
-                    data.forEach(team => {
-                        let row = document.createElement("tr");
-                        let trophy = team.rank === "1" ? "🏆" : "";
-                        let winPercentage = team.winPercentage !== null 
-                            ? parseFloat(team.winPercentage).toFixed(3) 
-                            : (team.wins / (team.wins + team.losses)).toFixed(3);
-
-                        row.innerHTML = `
-                            <td>${team.rank}️⃣ ${trophy}</td>
-                            <td><img src="https://www.mlbstatic.com/team-logos/${team.teamId}.svg" width="30"> ${team.name}</td>
-                            <td>${team.wins}</td>
-                            <td>${team.losses}</td>
-                            <td>${winPercentage}</td>
-                            <td>${team.gamesBack}</td>
-                        `;
-                        tbody.appendChild(row);
-                    });
-                }
-
-                populateTable(data["NL 東地区"], document.getElementById("nl-east-body"));
-                populateTable(data["NL 中地区"], document.getElementById("nl-central-body"));
-                populateTable(data["NL 西地区"], document.getElementById("nl-west-body"));
-            })
-            .catch(error => console.error("Error loading standings:", error));
     });
+
+    document.getElementById("prevBtn").addEventListener("click", function () {
+        currentIndex = (currentIndex - 1 + slides.length) % slides.length;
+        updateSlide();
+    });
+
+    // スワイプ対応
+    let startX = 0;
+    wrapper.addEventListener("touchstart", (e) => {
+        startX = e.touches[0].clientX;
+    });
+
+    wrapper.addEventListener("touchend", (e) => {
+        let endX = e.changedTouches[0].clientX;
+        if (startX - endX > 50) { 
+            currentIndex = (currentIndex + 1) % slides.length;
+        } else if (endX - startX > 50) {
+            currentIndex = (currentIndex - 1 + slides.length) % slides.length;
+        }
+        updateSlide();
+    });
+
+    // 🚀 **データを取得して各地区のテーブルに挿入**
+    fetch("/api/dodgers/standings")
+        .then(response => response.json())
+        .then(data => {
+            function populateTable(data, tbody) {
+                data.forEach(team => {
+                    let row = document.createElement("tr");
+                    let trophy = team.rank === "1" ? "🏆" : "";
+                    let winPercentage = team.winPercentage !== null 
+                        ? parseFloat(team.winPercentage).toFixed(3) 
+                        : (team.wins / (team.wins + team.losses)).toFixed(3);
+
+                    row.innerHTML = `
+                        <td>${team.rank}️⃣ ${trophy}</td>
+                        <td><img src="https://www.mlbstatic.com/team-logos/${team.teamId}.svg" width="30"> ${team.name}</td>
+                        <td>${team.wins}</td>
+                        <td>${team.losses}</td>
+                        <td>${winPercentage}</td>
+                        <td>${team.gamesBack}</td>
+                    `;
+                    tbody.appendChild(row);
+                });
+            }
+
+            // **各地区にデータを挿入**
+            const tableIds = {
+                "NL 東地区": "nl-east-body",
+                "NL 中地区": "nl-central-body",
+                "NL 西地区": "nl-west-body",
+                "AL 東地区": "al-east-body",
+                "AL 中地区": "al-central-body",
+                "AL 西地区": "al-west-body"
+            };
+
+            Object.entries(data).forEach(([key, value]) => {
+                let tableId = tableIds[key];
+                if (tableId) {
+                    let tbody = document.getElementById(tableId);
+                    if (tbody) {
+                        tbody.innerHTML = ""; // **前回のデータをクリア**
+                        populateTable(value, tbody);
+                    }
+                }
+            });
+        })
+        .catch(error => console.error("Error loading standings:", error));
+});
 </script>
+<!-- end MLB 地区別順位表 (スワイプ対応) -->
 
 
 
@@ -314,15 +284,15 @@ document.addEventListener('DOMContentLoaded', function () {
 
 
 <!--Start 動画セクション 2025-->
-    <div id="hoge-hoge_landing3" class="shiny-text-1">DodgerFest 2025: Shohei Ohtani interview</div>
-    <h5 class="shiny-text-1">今期のDodgerFestの動画です</h5>
-    <h5 class="shiny-text-1">消防署行った時と髪型が変わりましたね</h5>
-    <h5 class="shiny-text-1">順調そうで何よりです！</h5>
+    <div id="hoge-hoge_landing3" class="shiny-text-1"></div>
+    <h5 class="shiny-text-1">【2.6現地速報】ドジャース･大谷</h5>
+    <h5 class="shiny-text-1"> 4日連続で自主トレ捕手を座らせて</h5>
+    <h5 class="shiny-text-1">7球の投球練習～ベースランニングまでみっちり</h5>
 
         <div class="douga-section_3">
-            <div id="hoge-hoge_3">大谷翔平インタビュー</div>
+            <div id="hoge-hoge_3">【2.6現地速報】ドジャース･大谷</div>
             <div id="douga-container-3">
-                <iframe id="douga-video-3" width="560" height="315" src="https://www.youtube.com/embed/R6VnEjtxti4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                <iframe id="douga-video-3" width="560" height="315" src="https://www.youtube.com/embed/_9KuVWhQZoE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
             </div>
         </div>
 <!--End 動画セクション 2025-->

--- a/myProject202411122354/src/main/resources/templates/home.html
+++ b/myProject202411122354/src/main/resources/templates/home.html
@@ -110,6 +110,57 @@ document.addEventListener('DOMContentLoaded', function () {
 
 
 
+<!-- start NL西地区 順位表 -->
+    <div id="standings-table">
+        <h2>🏆 NL西地区 順位表</h2>
+        <table>
+            <thead>
+                <tr>
+                    <th>順位</th>
+                    <th>チーム</th>
+                    <th>勝</th>
+                    <th>負</th>
+                    <th>勝率</th>
+                    <th>ゲーム差</th>
+                </tr>
+            </thead>
+            <tbody id="standings-body"></tbody>
+        </table>
+    </div>
+
+    <script>
+        document.addEventListener("DOMContentLoaded", function () {
+            fetch("/api/dodgers/standings")
+                .then(response => response.json())
+                .then(data => {
+                    let tbody = document.getElementById("standings-body");
+                    tbody.innerHTML = "";
+
+                    data.forEach(team => {
+                        let row = document.createElement("tr");
+                        let trophy = team.rank === "1" ? "🏆" : "";
+                        
+                        row.innerHTML = `
+                            <td>${team.rank}️⃣ ${trophy}</td>
+                            <td><img src="https://www.mlbstatic.com/team-logos/${team.teamId}.svg" width="30"> ${team.name}</td>
+                            <td>${team.wins}</td>
+                            <td>${team.losses}</td>
+                            <td>${team.winPercentage}</td>
+                            <td>${team.gamesBack}</td>
+                        `;
+                        tbody.appendChild(row);
+                    });
+                })
+                .catch(error => console.error("Error loading standings:", error));
+        });
+    </script>
+<!-- End NL西地区 順位表 -->
+
+
+
+
+
+
     <h1 id="oomidashi" class="shiny-text">♥ワールドチャンピオンおめでとう♥</h1>
     <div id="confetti-container"><h1 id="fifty_fifty" class="shiny-text">大谷翔平MVP&54-59おめでとう</h1></div>
     <h5 class="shiny-text-1">目標は2025年MLB開幕戦Cubs対Dodgers観戦すること</h5>


### PR DESCRIPTION
feat: MLB順位表APIの実装とリーグ・地区別振り分け修正

- MLBの順位データを取得するAPIを作成 (`/api/dodgers/standings`)
- ナショナルリーグ (NL) & アメリカンリーグ (AL) のデータを統合
- チームを正しい地区 (東・中・西) に振り分け
  - ✅ Houston Astros (teamId: 117) → AL西地区へ修正
  - ✅ Chicago White Sox (teamId: 145) → AL中地区へ修正
- APIのレスポンス構造をフロントエンドと統一
- デフォルト表示を「NL西地区」に設定
- スワイプ機能 & フロントエンド連携の改善
🚀 MLB順位表が正しく表示されるようになりました！ 🎯