### PR TITLE
Feature/hit direction description db

### DIFF
--- a/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/controller/OhtaniScorebookController.java
+++ b/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/controller/OhtaniScorebookController.java
@@ -556,8 +556,23 @@ public class OhtaniScorebookController {
                                 "searchSummaryHtml",
                                 searchSummaryHtml);
 
-                // ★ チーム一覧を取得
-                List<String> opponents = mlbGameService.getAllOpponents();
+                // ============================================
+                // ★ チーム別打率ランキング--------------------棒グラフ用
+                // ============================================
+                List<Map<String, Object>> teamAvgList = mlbGameService.getTeamBattingAveragesAll(season);
+
+                for (Map<String, Object> team : teamAvgList) {
+
+                        String opponentName = (String) team.get("opponent");
+
+                        Integer teamId = mlbGameService.getTeamId(opponentName);
+
+                        team.put("teamId", teamId);
+                }
+
+                model.addAttribute(
+                                "teamAvgList",
+                                teamAvgList);
 
                 /*
                  * ============================================
@@ -656,6 +671,9 @@ public class OhtaniScorebookController {
                                 lOpsTrend.stream()
                                                 .map(OpsTrendDto::getCumulativeOps)
                                                 .toList());
+
+                // ★ チーム一覧を取得
+                List<String> opponents = mlbGameService.getAllOpponents();
 
                 // ★ 画面へ渡す
                 model.addAttribute("opponents", opponents);

--- a/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/controller/OhtaniScorebookController.java
+++ b/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/controller/OhtaniScorebookController.java
@@ -561,6 +561,13 @@ public class OhtaniScorebookController {
                 // ============================================
                 List<Map<String, Object>> teamAvgList = mlbGameService.getTeamBattingAveragesAll(season);
 
+                double maxTeamAvg = teamAvgList.stream()
+                                .map(team -> team.get("avg"))
+                                .filter(Objects::nonNull)
+                                .mapToDouble(avg -> ((Number) avg).doubleValue())
+                                .max()
+                                .orElse(1.0);
+
                 for (Map<String, Object> team : teamAvgList) {
 
                         String opponentName = (String) team.get("opponent");
@@ -568,11 +575,46 @@ public class OhtaniScorebookController {
                         Integer teamId = mlbGameService.getTeamId(opponentName);
 
                         team.put("teamId", teamId);
+
+                        Number avgNumber = (Number) team.get("avg");
+
+                        double avg = avgNumber == null
+                                        ? 0.0
+                                        : avgNumber.doubleValue();
+
+                        // double barPercent = maxTeamAvg == 0.0
+                        // ? 0.0
+                        // : (avg / maxTeamAvg) * 100.0;
+
+                        double barPercent = avg * 100.0;
+
+                        team.put("barPercent", barPercent);
                 }
 
                 model.addAttribute(
                                 "teamAvgList",
                                 teamAvgList);
+
+                // ============================================
+                // ★ チーム別打率ランキングのチームをNL/ALに分ける--------------------棒グラフ用
+                // ============================================
+                List<Map<String, Object>> nlTeamAvgList = teamAvgList.stream()
+                                .filter(team -> mlbGameService.isNationalLeagueTeam(
+                                                (String) team.get("opponent")))
+                                .toList();
+
+                List<Map<String, Object>> alTeamAvgList = teamAvgList.stream()
+                                .filter(team -> !mlbGameService.isNationalLeagueTeam(
+                                                (String) team.get("opponent")))
+                                .toList();
+
+                model.addAttribute(
+                                "nlTeamAvgList",
+                                nlTeamAvgList);
+
+                model.addAttribute(
+                                "alTeamAvgList",
+                                alTeamAvgList);
 
                 /*
                  * ============================================

--- a/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/repository/OhtaniGameRepository.java
+++ b/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/repository/OhtaniGameRepository.java
@@ -7541,4 +7541,136 @@ public class OhtaniGameRepository {
                         rs.getString("game_date"),
                         rs.getDouble("cumulative_ops")));
     }
+
+    /**
+     * ============================================
+     * ★ チーム別打率一覧（ALL投手）--------------------棒グラフ用
+     * ============================================
+     */
+    public List<Map<String, Object>> getTeamBattingAveragesAll(
+            Integer season) {
+
+        String sql = """
+                SELECT
+                    opponent,
+                    SUM(CASE WHEN result IN ('HIT','HR') THEN 1 ELSE 0 END) AS hits,
+                    SUM(
+                        CASE
+                            WHEN result NOT IN ('BB','SF')
+                            AND result IS NOT NULL
+                            THEN 1
+                            ELSE 0
+                        END
+                    ) AS at_bats,
+                    ROUND(
+                        SUM(CASE WHEN result IN ('HIT','HR') THEN 1 ELSE 0 END) * 1.0
+                        /
+                        NULLIF(
+                            SUM(
+                                CASE
+                                    WHEN result NOT IN ('BB','SF')
+                                    AND result IS NOT NULL
+                                    THEN 1
+                                    ELSE 0
+                                END
+                            ),
+                            0
+                        ),
+                        3
+                    ) AS avg
+                FROM (
+                    SELECT
+                        g.opponent,
+                        d.pa1_result AS result
+                    FROM ohtani_game_details d
+                    JOIN ohtani_games g
+                        ON d.game_id = g.id
+                    WHERE EXTRACT(YEAR FROM d.created_at) = ?
+                      AND d.pa1_description IS NOT NULL
+                      AND d.pa1_description <> 'dammydammy'
+
+                    UNION ALL
+
+                    SELECT
+                        g.opponent,
+                        d.pa2_result
+                    FROM ohtani_game_details d
+                    JOIN ohtani_games g
+                        ON d.game_id = g.id
+                    WHERE EXTRACT(YEAR FROM d.created_at) = ?
+                      AND d.pa2_description IS NOT NULL
+                      AND d.pa2_description <> 'dammydammy'
+
+                    UNION ALL
+
+                    SELECT
+                        g.opponent,
+                        d.pa3_result
+                    FROM ohtani_game_details d
+                    JOIN ohtani_games g
+                        ON d.game_id = g.id
+                    WHERE EXTRACT(YEAR FROM d.created_at) = ?
+                      AND d.pa3_description IS NOT NULL
+                      AND d.pa3_description <> 'dammydammy'
+
+                    UNION ALL
+
+                    SELECT
+                        g.opponent,
+                        d.pa4_result
+                    FROM ohtani_game_details d
+                    JOIN ohtani_games g
+                        ON d.game_id = g.id
+                    WHERE EXTRACT(YEAR FROM d.created_at) = ?
+                      AND d.pa4_description IS NOT NULL
+                      AND d.pa4_description <> 'dammydammy'
+
+                    UNION ALL
+
+                    SELECT
+                        g.opponent,
+                        d.pa5_result
+                    FROM ohtani_game_details d
+                    JOIN ohtani_games g
+                        ON d.game_id = g.id
+                    WHERE EXTRACT(YEAR FROM d.created_at) = ?
+                      AND d.pa5_description IS NOT NULL
+                      AND d.pa5_description <> 'dammydammy'
+
+                    UNION ALL
+
+                    SELECT
+                        g.opponent,
+                        d.pa6_result
+                    FROM ohtani_game_details d
+                    JOIN ohtani_games g
+                        ON d.game_id = g.id
+                    WHERE EXTRACT(YEAR FROM d.created_at) = ?
+                      AND d.pa6_description IS NOT NULL
+                      AND d.pa6_description <> 'dammydammy'
+                ) t
+                WHERE opponent IS NOT NULL
+                GROUP BY opponent
+                HAVING
+                    SUM(
+                        CASE
+                            WHEN result NOT IN ('BB','SF')
+                            AND result IS NOT NULL
+                            THEN 1
+                            ELSE 0
+                        END
+                    ) > 0
+                ORDER BY avg DESC, opponent ASC
+                """;
+
+        return jdbcTemplate.queryForList(
+                sql,
+                season,
+                season,
+                season,
+                season,
+                season,
+                season);
+    }
+
 }

--- a/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/service/MLBGameService.java
+++ b/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/service/MLBGameService.java
@@ -63,6 +63,34 @@ public class MLBGameService {
         return TEAM_IDS.get(opponent);
     }
 
+    // ============================================
+    // ★ NLチーム判定--------------------棒グラフ用
+    // ============================================
+    public boolean isNationalLeagueTeam(String opponent) {
+
+        return switch (opponent) {
+
+            case "Arizona Diamondbacks",
+                    "Atlanta Braves",
+                    "Chicago Cubs",
+                    "Cincinnati Reds",
+                    "Colorado Rockies",
+                    "Los Angeles Dodgers",
+                    "Miami Marlins",
+                    "Milwaukee Brewers",
+                    "New York Mets",
+                    "Philadelphia Phillies",
+                    "Pittsburgh Pirates",
+                    "San Diego Padres",
+                    "San Francisco Giants",
+                    "St. Louis Cardinals",
+                    "Washington Nationals" ->
+                true;
+
+            default -> false;
+        };
+    }
+
     private final String BASE_URL = "https://statsapi.mlb.com/api/v1/schedule/games/";
     private final String SCHEDULE_URL = "https://statsapi.mlb.com/api/v1/schedule";
     private final OhtaniGameRepository ohtaniGameRepository;

--- a/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/service/MLBGameService.java
+++ b/myProject202411122354/src/main/java/com/example/dodgersshoheiapp/service/MLBGameService.java
@@ -17,6 +17,52 @@ import java.util.regex.Pattern;
 @RequiredArgsConstructor
 public class MLBGameService {
 
+    // ============================================
+    // ★ MLB Team ID--------------------棒グラフ用
+    // ============================================
+    private static final Map<String, Integer> TEAM_IDS = Map.ofEntries(
+
+            Map.entry("Arizona Diamondbacks", 109),
+            Map.entry("Atlanta Braves", 144),
+            Map.entry("Baltimore Orioles", 110),
+            Map.entry("Boston Red Sox", 111),
+            Map.entry("Chicago Cubs", 112),
+            Map.entry("Chicago White Sox", 145),
+            Map.entry("Cincinnati Reds", 113),
+            Map.entry("Cleveland Guardians", 114),
+            Map.entry("Colorado Rockies", 115),
+            Map.entry("Detroit Tigers", 116),
+            Map.entry("Houston Astros", 117),
+            Map.entry("Kansas City Royals", 118),
+            Map.entry("Los Angeles Angels", 108),
+            Map.entry("Los Angeles Dodgers", 119),
+            Map.entry("Miami Marlins", 146),
+            Map.entry("Milwaukee Brewers", 158),
+            Map.entry("Minnesota Twins", 142),
+            Map.entry("New York Mets", 121),
+            Map.entry("New York Yankees", 147),
+            Map.entry("Oakland Athletics", 133),
+            Map.entry("Philadelphia Phillies", 143),
+            Map.entry("Pittsburgh Pirates", 134),
+            Map.entry("San Diego Padres", 135),
+            Map.entry("San Francisco Giants", 137),
+            Map.entry("Seattle Mariners", 136),
+            Map.entry("St. Louis Cardinals", 138),
+            Map.entry("Tampa Bay Rays", 139),
+            Map.entry("Texas Rangers", 140),
+            Map.entry("Toronto Blue Jays", 141),
+            Map.entry("Washington Nationals", 120)
+
+    );
+
+    // ============================================
+    // ★ Team ID取得--------------------棒グラフ用
+    // ============================================
+    public Integer getTeamId(String opponent) {
+
+        return TEAM_IDS.get(opponent);
+    }
+
     private final String BASE_URL = "https://statsapi.mlb.com/api/v1/schedule/games/";
     private final String SCHEDULE_URL = "https://statsapi.mlb.com/api/v1/schedule";
     private final OhtaniGameRepository ohtaniGameRepository;
@@ -2482,4 +2528,16 @@ public class MLBGameService {
                 pitcherHand,
                 season);
     }
+
+    /**
+     * ============================================
+     * ★ チーム別打率一覧--------------------棒グラフ用
+     * ============================================
+     */
+    public List<Map<String, Object>> getTeamBattingAveragesAll(
+            Integer season) {
+
+        return ohtaniGameRepository.getTeamBattingAveragesAll(season);
+    }
+
 }

--- a/myProject202411122354/src/main/resources/static/css/batting_filter.css
+++ b/myProject202411122354/src/main/resources/static/css/batting_filter.css
@@ -1998,11 +1998,12 @@ body.risp-mode {
     margin-bottom:20px;
 }
 
-.team-avg-item{
-    display:flex;
-    align-items:center;
-    gap:12px;
-    margin-bottom:12px;
+.team-avg-item {
+    display: grid;
+    grid-template-columns: 42px minmax(160px, 1fr) 64px 70px;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 12px;
 }
 
 .team-logo{
@@ -2035,6 +2036,131 @@ body.risp-mode {
     width:220px;
 }
 
+/* =====================================================
+   チーム別打率ランキング NL / AL 2カラム--------------------棒グラフ用
+===================================================== */
+
+.team-avg-league-grid {
+    display: grid;
+    /* grid-template-columns: 1fr 1fr; */
+    gap: 36px;
+}
+
+.team-avg-league-title {
+    color: #ffffff;
+    font-size: 20px;
+    font-weight: 800;
+    margin: 0 0 18px;
+    opacity: 0.9;
+}
+
+.team-detail {
+    color: rgba(255,255,255,0.65);
+    font-weight: 600;
+    min-width: 70px;
+}
+
+/* =====================================================
+   チーム別打率ランキング NL / AL 目盛り--------------------棒グラフ用
+===================================================== */
+/* .team-scale {
+    display: flex;
+    justify-content: space-between;
+    margin-left: 55px;
+    margin-bottom: 8px;
+
+    color: #ffffff;
+    font-size: 11px;
+    font-weight: 600;
+} */
+
+/* =====================================================
+   チーム別打率ランキング 目盛り
+===================================================== */
+
+.team-scale-row {
+    display: grid;
+    grid-template-columns: 42px minmax(160px, 1fr) 64px 70px;
+    gap: 12px;
+    align-items: end;
+    margin-bottom: 8px;
+}
+
+.team-scale {
+    display: grid;
+    grid-template-columns: repeat(11, 1fr);
+    width: 100%;
+    color: rgba(255,255,255,0.9);
+    font-size: 11px;
+    font-weight: 700;
+}
+
+.team-scale span {
+    position: relative;
+    text-align: left;
+}
+
+.team-scale span::before {
+    content: "";
+    display: block;
+    width: 2px;
+    height: 12px;
+    background: rgba(255,255,255,0.9);
+    margin-bottom: 2px;
+}
+
+
+/* =====================================================
+   チーム別打率ランキング スマホでも2列維持--------------------棒グラフ用
+===================================================== */
+/* @media (max-width: 430px) {
+
+    .team-avg-league-grid {
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) !important;
+        gap: 10px !important;
+    }
+
+    .team-avg-league-title {
+        font-size: 12px;
+        margin-bottom: 8px;
+    }
+
+    .team-avg-item {
+        display: grid;
+        grid-template-columns: 22px minmax(0, 1fr) !important;
+        gap: 4px;
+        margin-bottom: 8px;
+        align-items: center;
+    }
+
+    .team-logo {
+        width: 18px;
+        height: 18px;
+    }
+
+    .team-bar-wrap {
+        grid-column: 2;
+        grid-row: 1;
+        width: 100% !important;
+        min-width: 0;
+        height: 10px;
+    }
+
+    .team-avg-value {
+        grid-column: 2;
+        grid-row: 1;
+        justify-self: end;
+        z-index: 2;
+        font-size: 9px;
+        min-width: 0;
+        padding-right: 3px;
+        color: #ffffff;
+    }
+
+    .team-detail {
+        display: none !important;
+    }
+} */
 
 /* =========================================
     mobile
@@ -2152,4 +2278,180 @@ body.risp-mode {
 
         height: 520px;
     }
+}
+
+/* =====================================================
+   チーム別打率ランキング スマホ2列・棒幅調整 強制版--------------------棒グラフ用
+===================================================== */
+
+@media (max-width: 430px) {
+
+    .team-avg-section .team-avg-league-grid {
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) !important;
+        gap: 10px !important;
+    }
+
+    .team-avg-section .team-avg-item {
+        display: grid !important;
+        grid-template-columns: 22px 88px 34px !important;
+        gap: 4px !important;
+        align-items: center !important;
+        margin-bottom: 8px !important;
+    }
+
+    .team-avg-section .team-logo {
+        width: 18px !important;
+        height: 18px !important;
+    }
+
+    .team-avg-section .team-bar-wrap {
+        width: 88px !important;
+        max-width: 88px !important;
+        min-width: 88px !important;
+        height: 10px !important;
+    }
+
+    .team-avg-section .team-avg-value {
+        min-width: 32px !important;
+        font-size: 9px !important;
+        text-align: right !important;
+    }
+
+    .team-avg-section .team-detail {
+        display: none !important;
+    }
+
+        .team-avg-section .team-scale-row {
+        display: grid !important;
+        grid-template-columns: 22px 88px 34px !important;
+        gap: 4px !important;
+        align-items: end !important;
+        margin-bottom: 4px !important;
+    }
+
+    .team-avg-section .team-scale {
+        grid-column: 2 !important;
+        width: 88px !important;
+        font-size: 6px !important;
+        line-height: 1 !important;
+    }
+
+    .team-avg-section .team-scale span::before {
+        width: 1px !important;
+        height: 6px !important;
+        margin-bottom: 1px !important;
+    }
+}
+
+/* =====================================================
+   チーム別打率ランキング 目盛り・棒幅 同期版
+===================================================== */
+
+.team-avg-section {
+    --team-bar-width: 500px;
+}
+
+.team-avg-item {
+    grid-template-columns: 42px var(--team-bar-width) 64px 70px !important;
+}
+
+.team-scale-row {
+    grid-template-columns: 42px var(--team-bar-width) 64px 70px !important;
+}
+
+.team-bar-wrap {
+    width: 91% !important;
+    max-width: none !important;
+    min-width: 0 !important;
+}
+
+.team-scale {
+    width: 100% !important;
+}
+
+/* スマホ */
+@media (max-width: 430px) {
+
+    .team-avg-section {
+        --team-bar-width: 88px;
+    }
+
+    .team-avg-item {
+        grid-template-columns: 22px var(--team-bar-width) 34px !important;
+    }
+
+    .team-scale-row {
+        grid-template-columns: 22px var(--team-bar-width) 34px !important;
+    }
+
+    .team-scale {
+        grid-column: 2 !important;
+        font-size: 6px !important;
+    }
+
+    .team-detail {
+        display: none !important;
+    }
+}
+
+/* =====================================================
+   チーム別打率ランキング AVG位置調整
+===================================================== */
+
+.team-avg-value {
+    text-align: left;
+    justify-self: start;
+    margin-left: -4px;
+}
+
+.team-detail {
+    justify-self: start;
+    margin-left: -8px;
+}
+
+
+/* =====================================================
+   チーム別打率ランキング NL縦ガイドライン
+===================================================== */
+
+.nl-team-avg-col .team-bar-wrap {
+    background:
+        repeating-linear-gradient(
+            to right,
+            rgba(255,255,255,0.12) 0,
+            rgba(255,255,255,0.12) 1px,
+            transparent 1px,
+            transparent 10%
+        ),
+        rgba(255,255,255,0.08);
+}
+
+/* =====================================================
+   チーム別打率ランキング AL縦ガイドライン
+===================================================== */
+
+.al-team-avg-col .team-bar-wrap {
+    background:
+        repeating-linear-gradient(
+            to right,
+            rgba(255,255,255,0.12) 0,
+            rgba(255,255,255,0.12) 1px,
+            transparent 1px,
+            transparent 10%
+        ),
+        rgba(255,255,255,0.08);
+}
+
+
+.padres-logo{
+    background: rgb(255 253 0 / 86%);
+    border-radius: 50%;
+    padding: 1px;
+}
+
+
+.rockies-logo{
+    background: rgb(180 19 255);
+    border-radius: 50%;
+    padding: 1px;
 }

--- a/myProject202411122354/src/main/resources/static/css/batting_filter.css
+++ b/myProject202411122354/src/main/resources/static/css/batting_filter.css
@@ -1983,6 +1983,57 @@ body.risp-mode {
 }
 
 
+/* =====================================================
+   チーム別打率ランキング--------------------棒グラフ用
+===================================================== */
+
+.team-avg-section{
+    margin:40px 0;
+}
+
+.team-avg-title{
+    color:#fff;
+    font-size:28px;
+    font-weight:bold;
+    margin-bottom:20px;
+}
+
+.team-avg-item{
+    display:flex;
+    align-items:center;
+    gap:12px;
+    margin-bottom:12px;
+}
+
+.team-logo{
+    width:32px;
+    height:32px;
+    flex-shrink:0;
+}
+
+.team-bar-wrap{
+    width:500px;
+    height:18px;
+    background:rgba(255,255,255,0.08);
+    border-radius:10px;
+    overflow:hidden;
+}
+
+.team-bar{
+    height:100%;
+    background:#19bfff;
+}
+
+.team-avg-value{
+    color:white;
+    font-weight:bold;
+    min-width:60px;
+}
+
+.team-name{
+    color:white;
+    width:220px;
+}
 
 
 /* =========================================

--- a/myProject202411122354/src/main/resources/static/css/batting_filter.css
+++ b/myProject202411122354/src/main/resources/static/css/batting_filter.css
@@ -1988,7 +1988,7 @@ body.risp-mode {
 ===================================================== */
 
 .team-avg-section{
-    margin:40px 0;
+    margin:10px 0;
 }
 
 .team-avg-title{
@@ -2042,7 +2042,7 @@ body.risp-mode {
 
 .team-avg-league-grid {
     display: grid;
-    /* grid-template-columns: 1fr 1fr; */
+    grid-template-columns: 1fr 1fr;
     gap: 36px;
 }
 
@@ -2454,4 +2454,20 @@ body.risp-mode {
     background: rgb(180 19 255);
     border-radius: 50%;
     padding: 1px;
+}
+
+/* =====================================================
+   チーム別打率ランキングだけ スマホ縮尺表示
+   ※ viewport metaなし前提
+===================================================== */
+@media (max-width: 1000px) {
+
+    .team-avg-section {
+        overflow: hidden;
+    }
+
+    .team-avg-league-grid {
+        zoom: 0.65;
+        transform-origin: top left;
+    }
 }

--- a/myProject202411122354/src/main/resources/templates/batting_filter.html
+++ b/myProject202411122354/src/main/resources/templates/batting_filter.html
@@ -658,13 +658,48 @@
         </div><!--34行目のfilter-panelの閉じタグ-->
 
 
-<!--<div class="direction-chart-wrapper">
+            <!-- =========================================================
+                チーム別打率ランキング--------------------棒グラフ用
+            ========================================================= -->
+            <div class="team-avg-section">
 
-    <h2>打球方向分析</h2>
+                <h2 class="team-avg-title">チーム別打率</h2>
 
-    <canvas id="hitDirectionChart"></canvas>
+                <div class="team-avg-item"
+                    th:each="team : ${teamAvgList}">
 
-</div>-->
+                    <!-- MLBロゴ -->
+                    <img class="team-logo"
+                        th:if="${team['teamId'] != null}"
+                        th:src="|https://www.mlbstatic.com/team-logos/${team['teamId']}.svg|">
+
+                    <!-- チーム名 -->
+                    <span class="team-name"
+                        th:text="${team['opponent']}">
+                    </span>
+
+                    <!-- 横棒 -->
+                    <div class="team-bar-wrap">
+
+                        <div class="team-bar"
+                            th:style="'width:' + (${team['avg']} * 100) + '%'">
+                        </div>
+
+                    </div>
+
+                    <!-- 打率 -->
+                    <span class="team-avg-value"
+                        th:text="${team['avg']}">
+                    </span>
+
+                    <!-- ヒット数 -->
+                    <span style="color:#aaa;"
+                        th:text="'(' + ${team['hits']} + '-' + ${team['at_bats']} + ')'">
+                    </span>
+
+                </div>
+
+            </div>
 
 
         <hr>

--- a/myProject202411122354/src/main/resources/templates/batting_filter.html
+++ b/myProject202411122354/src/main/resources/templates/batting_filter.html
@@ -658,49 +658,145 @@
         </div><!--34行目のfilter-panelの閉じタグ-->
 
 
-            <!-- =========================================================
-                チーム別打率ランキング--------------------棒グラフ用
-            ========================================================= -->
+    <!-- =========================================================
+        チーム別打率ランキング--------------------棒グラフ用
+    ========================================================= -->
             <div class="team-avg-section">
 
                 <h2 class="team-avg-title">チーム別打率</h2>
 
-                <div class="team-avg-item"
-                    th:each="team : ${teamAvgList}">
+                <div class="team-avg-league-grid">
 
-                    <!-- MLBロゴ -->
-                    <img class="team-logo"
-                        th:if="${team['teamId'] != null}"
-                        th:src="|https://www.mlbstatic.com/team-logos/${team['teamId']}.svg|">
+                    <!-- =========================
+                        NL
+                    ========================= -->
+                    <div class="team-avg-league-col nl-team-avg-col">
 
-                    <!-- チーム名 -->
-                    <span class="team-name"
-                        th:text="${team['opponent']}">
-                    </span>
+                        <h3 class="team-avg-league-title">National League</h3>
 
-                    <!-- 横棒 -->
-                    <div class="team-bar-wrap">
+<div class="team-scale-row">
 
-                        <div class="team-bar"
-                            th:style="'width:' + (${team['avg']} * 100) + '%'">
+    <div></div>
+
+    <div class="team-scale">
+        <span>0.000</span>
+        <span>0.100</span>
+        <span>0.200</span>
+        <span>0.300</span>
+        <span>0.400</span>
+        <span>0.500</span>
+        <span>0.600</span>
+        <span>0.700</span>
+        <span>0.800</span>
+        <span>0.900</span>
+        <span>1.000</span>
+    </div>
+
+    <div></div>
+    <div></div>
+
+</div>
+
+                        <div class="team-avg-item"
+                            th:each="team : ${nlTeamAvgList}">
+
+                        <img class="team-logo"
+                            th:if="${team['teamId'] != null}"
+                            th:classappend="
+                                ${team['teamId'] == 135} ? ' padres-logo' :
+                                (${team['teamId'] == 115} ? ' rockies-logo' : '')
+                            "
+                            th:src="|https://www.mlbstatic.com/team-logos/${team['teamId']}.svg|">
+
+                            <!--<span class="team-name"
+                                th:text="${team['opponent']}">
+                            </span>-->
+
+                            <div class="team-bar-wrap">
+
+                                <div class="team-bar"
+                                    th:style="'width:' + ${team['barPercent']} + '%'">
+                                </div>
+
+                            </div>
+
+                            <span class="team-avg-value"
+                                th:text="${team['avg']}">
+                            </span>
+
+                            <span class="team-detail"
+                                th:text="'(' + ${team['hits']} + '-' + ${team['at_bats']} + ')'">
+                            </span>
+
                         </div>
 
                     </div>
 
-                    <!-- 打率 -->
-                    <span class="team-avg-value"
-                        th:text="${team['avg']}">
-                    </span>
+                    <!-- =========================
+                        AL
+                    ========================= -->
+                    <div class="team-avg-league-col al-team-avg-col">
 
-                    <!-- ヒット数 -->
-                    <span style="color:#aaa;"
-                        th:text="'(' + ${team['hits']} + '-' + ${team['at_bats']} + ')'">
-                    </span>
+                        <h3 class="team-avg-league-title">American League</h3>
+
+<div class="team-scale-row">
+
+    <div></div>
+
+    <div class="team-scale">
+        <span>0.000</span>
+        <span>0.100</span>
+        <span>0.200</span>
+        <span>0.300</span>
+        <span>0.400</span>
+        <span>0.500</span>
+        <span>0.600</span>
+        <span>0.700</span>
+        <span>0.800</span>
+        <span>0.900</span>
+        <span>1.000</span>
+    </div>
+
+    <div></div>
+    <div></div>
+
+</div>
+
+
+                        <div class="team-avg-item"
+                            th:each="team : ${alTeamAvgList}">
+
+                            <img class="team-logo"
+                                th:if="${team['teamId'] != null}"
+                                th:src="|https://www.mlbstatic.com/team-logos/${team['teamId']}.svg|">
+
+                            <!--<span class="team-name"
+                                th:text="${team['opponent']}">
+                            </span>-->
+
+                            <div class="team-bar-wrap">
+
+                                <div class="team-bar"
+                                    th:style="'width:' + ${team['barPercent']} + '%'">
+                                </div>
+
+                            </div>
+
+                            <span class="team-avg-value"
+                                th:text="${team['avg']}">
+                            </span>
+
+                            <span class="team-detail"
+                                th:text="'(' + ${team['hits']} + '-' + ${team['at_bats']} + ')'">
+                            </span>
+
+                        </div>
+
+                    </div>
 
                 </div>
 
             </div>
-
 
         <hr>
 

--- a/myProject202411122354/src/main/resources/templates/batting_filter.html
+++ b/myProject202411122354/src/main/resources/templates/batting_filter.html
@@ -655,7 +655,7 @@
             </div>
 
         </div>
-        </div><!--34行目のfilter-panelの閉じタグ-->
+        <!--</div>34行目のfilter-panelの閉じタグ-->-->
 
 
     <!-- =========================================================
@@ -663,7 +663,7 @@
     ========================================================= -->
             <div class="team-avg-section">
 
-                <h2 class="team-avg-title">チーム別打率</h2>
+                <h2 class="team-avg-title">2026_チーム別打率 どのチームから打てているか?!ランキング</h2>
 
                 <div class="team-avg-league-grid">
 
@@ -679,17 +679,17 @@
     <div></div>
 
     <div class="team-scale">
-        <span>0.000</span>
-        <span>0.100</span>
-        <span>0.200</span>
-        <span>0.300</span>
-        <span>0.400</span>
-        <span>0.500</span>
-        <span>0.600</span>
-        <span>0.700</span>
-        <span>0.800</span>
-        <span>0.900</span>
-        <span>1.000</span>
+        <span>0.0</span>
+        <span>0.1</span>
+        <span>0.2</span>
+        <span>0.3</span>
+        <span>0.4</span>
+        <span>0.5</span>
+        <span>0.6</span>
+        <span>0.7</span>
+        <span>0.8</span>
+        <span>0.9</span>
+        <span>1.0</span>
     </div>
 
     <div></div>
@@ -744,17 +744,17 @@
     <div></div>
 
     <div class="team-scale">
-        <span>0.000</span>
-        <span>0.100</span>
-        <span>0.200</span>
-        <span>0.300</span>
-        <span>0.400</span>
-        <span>0.500</span>
-        <span>0.600</span>
-        <span>0.700</span>
-        <span>0.800</span>
-        <span>0.900</span>
-        <span>1.000</span>
+        <span>0.0</span>
+        <span>0.1</span>
+        <span>0.2</span>
+        <span>0.3</span>
+        <span>0.4</span>
+        <span>0.5</span>
+        <span>0.6</span>
+        <span>0.7</span>
+        <span>0.8</span>
+        <span>0.9</span>
+        <span>1.0</span>
     </div>
 
     <div></div>
@@ -851,6 +851,7 @@
 </div>
 
 
+    </div><!--34行目のfilter-panelの閉じタグ-->
 
 
     <!-- =========================


### PR DESCRIPTION
完了事項

チーム別打率ランキング実装

NL / AL 並列表示

MLBロゴ表示

AVGランキング表示

AVG + H-AB表示

横棒グラフ表示

0.000〜1.000スケール表示

縦ガイドライン表示

Padresロゴ視認性改善

Rockiesロゴ視認性改善

.team-bar-wrap { width:91% !important; } による目盛り整合

スマホ表示時

zoom:0.65

transform-origin: top left

NL/AL 2列維持